### PR TITLE
Change analytics to Fathom + add GH templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners are automatically requested for review when someone opens a pull request that modifies code that they own. This helps speed up the review process and ensures we adhere the standards we set up for ourselves.
+
+# @thefoxis owns the perf.email website:
+* @thefoxis

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+> ℹ️ This template will help you describe the work you’ve done, so it can be easily reviewed and referenced in the future. Please fill relevant sections below and delete the help notes before submitting. In some contexts, certain sections might not be relevant. In those cases, feel free to remove them too. 🙌🏻 
+
+> Remember to [set your PR as draft](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests) when you’re actively working on it. Switch to ready for review once you’re ready for feedback and select relevant teammates. 🥳
+
+***
+
+## What does this PR introduce?
+
+> ℹ️ In a few bullet points or sentences, please describe the changes this Pull Request makes: what’s the scope of the changes? Why are you making them? What’s the impact? Are there any gotchas to pay attention to? You don’t have to copy-paste all commit messages, but provide enough information, so the person reviewing the work can understand its implications.
+
+> * **example:** This PR adds Release Notes for March 2022 and updates documentation screenshots for initial site email, since we added a fourth metric and previous ones were out of date.
+
+## Related issues
+
+> ℹ️ We track work in several places depending on its type. For editorial and copy changes, reference the Notion document. For development work, make sure to [link this Pull Request to a relevant Linear issue](https://linear.app/docs/github#link-prs).
+
+> * **example:** [Release Notes: March](https://www.notion.so/calibre/Release-Notes-March-4def4cff46db4912b330000f3e5f79ca)
+> * **example:** fixes CAL-44
+
+## Preview
+
+> ℹ️ If the work introduces new functionality, visual changes or new content, please provide link(s) to the affected areas. Screenshots are welcome, but optional. 
+> * **example:** [Pricing page preview](https://calibreapp.com/pricing)

--- a/src/index.html
+++ b/src/index.html
@@ -29,6 +29,8 @@
   <link rel="icon" href="https://perf.email/favicons/icon.svg" type="image/svg+xml">
   <link rel="apple-touch-icon" href="https://perf.email/favicons/apple-touch-icon.png">
   <link rel="manifest" href="https://perf.email/manifest.webmanifest">
+
+  <script src="https://cdn.usefathom.com/script.js" data-site="DTGXNNZT" defer></script>
 </head>
 
 <body>

--- a/vercel.json
+++ b/vercel.json
@@ -3,14 +3,6 @@
     {
       "source": "/rss",
       "destination": "/api/rss"
-    },
-    {
-      "source": "/bee.js",
-      "destination": "https://cdn.splitbee.io/sb.js"
-    },
-    {
-      "source": "/_hive/:slug",
-      "destination": "https://hive.splitbee.io/:slug"
     }
   ]
 }


### PR DESCRIPTION
## What does this PR introduce?

* removes Splitbee analytics (since we're not using it) and replaces it with Fathom (since we're trying it out!)
* adds `CODEOWNERS` and PR template as in calibreapp/web#1077 and calibreapp/app#2772